### PR TITLE
Fixed fetching of index

### DIFF
--- a/FastExcel/FastExcel.Worksheets.cs
+++ b/FastExcel/FastExcel.Worksheets.cs
@@ -51,9 +51,7 @@ namespace FastExcel
                 foreach (var sheetElement in sheetsElements)
                 {
                     var worksheet = new Worksheet(this);
-                    worksheet.Index = (from attribute in sheetElement.Attributes()
-                                  where attribute.Name == "sheetId"
-                                  select int.Parse(attribute.Value)).FirstOrDefault();
+                    worksheet.Index = sheetsElements.IndexOf(sheetElement) + 1;
 
                     worksheet.Name = (from attribute in sheetElement.Attributes()
                                  where attribute.Name == "name"

--- a/FastExcel/Worksheet.cs
+++ b/FastExcel/Worksheet.cs
@@ -504,11 +504,9 @@ namespace FastExcel
                         }
                     }
                 }
-
-                this.Index = (from attribute in sheetElement.Attributes()
-                              where attribute.Name == "sheetId"
-                              select int.Parse(attribute.Value)).FirstOrDefault();
-
+                               
+                this.Index = sheetsElements.IndexOf(sheetElement)+1;
+                
                 this.Name = (from attribute in sheetElement.Attributes()
                               where attribute.Name == "name"
                               select attribute.Value).FirstOrDefault();


### PR DESCRIPTION
Previously was using sheetId which could be non uniform. I.e. adding and
removing sheets could cause the numbers to be inconsistent with what
ends up in the archive.
Using the index in which they appear in the sheetsElements allows for
this inconsistency, this way the first sheet is always index 1, and is
sheet1.xml in the archive.

Fixes #4