### PR TITLE
return proper text value when not string

### DIFF
--- a/FastExcel/Cell.cs
+++ b/FastExcel/Cell.cs
@@ -104,7 +104,19 @@ namespace FastExcel
             }
             else
             {
-                Value = cellElement.Value;
+                // cellElement.Value will give a concatenated Value + reference/calculation
+
+                var node = cellElement.Elements().Where(x => x.Name.LocalName == "v").SingleOrDefault();
+
+                if (node != null)
+                {
+                    Value = node.Value;
+                }
+                else
+                {
+                    Value = cellElement.Value;
+                }
+                
             }
         }
 


### PR DESCRIPTION
I've actually modified the bit setting value, as the concatenated expression+value probably isn't that useful